### PR TITLE
Magento 2.4.4 compatibility

### DIFF
--- a/Logger/Handler/Debug.php
+++ b/Logger/Handler/Debug.php
@@ -20,7 +20,7 @@ class Debug extends \Magento\Framework\Logger\Handler\Debug
      * @param array $record
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function write(array $record)
+    protected function write(array $record): void
     {
         if (!isset($record['context']['is_api']) || !$record['context']['is_api']) {
             parent::write($record);

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "homepage": "https://github.com/vladflonta"
     }],
     "require": {
+        "magento/framework": "^103.0.4",
         "magento/module-webapi": ">=100.0.2"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Magento 2.4.4 changed the method signature of `\Magento\Framework\Logger\Handler\Base::write` which leads to the following errror:
`Fatal Error: 'Declaration of VladFlonta\\WebApiLog\\Logger\\Handler\\Debug::write(array $record) must be compatible with Magento\\Framework\\Logger\\Handler\\Base::write(array $record): void' in '/vendor\/vladflonta\/magento2-webapi-log\/Logger\/Handler\/Debug.php' on line 23`