### PR TITLE
feat: record the name of the integration being used to auth requests

### DIFF
--- a/Logger/Handler/Debug.php
+++ b/Logger/Handler/Debug.php
@@ -8,6 +8,8 @@
 
 namespace VladFlonta\WebApiLog\Logger\Handler;
 
+use Monolog\LogRecord;
+
 class Debug extends \Magento\Framework\Logger\Handler\Debug
 {
     /** @var string */
@@ -37,10 +39,10 @@ class Debug extends \Magento\Framework\Logger\Handler\Debug
     }
 
     /**
-     * @param array $record
+     * @param \Monolog\LogRecord $record
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         if (!isset($record['context']['is_api']) || !$record['context']['is_api']) {
             parent::write($record);

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -51,4 +51,12 @@ class Config
     {
         return (bool) $this->scopeConfig->getValue(self::XML_PATH_WEBAPI_LOGGER.'enable', 'store');
     }
+
+    /**
+     * @return boolean
+     */
+    public function isIntegrationNameEnabled()
+    {
+        return (bool)$this->scopeConfig->getValue(self::XML_PATH_WEBAPI_LOGGER.'enable_integration_name', 'store');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "psr-4": {
             "VladFlonta\\WebApiLog\\": ""
         }
+    },
+    "replace": {
+        "vladflonta/magento2-webapi-log": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     }],
     "require": {
         "magento/framework": "^103.0.4",
-        "magento/module-webapi": ">=100.0.2"
+        "magento/module-webapi": ">=100.0.2",
+        "monolog/monolog": "^3.9"
     },
     "type": "magento2-module",
     "license": "OSL-3.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "magento/module-webapi": ">=100.0.2"
     },
     "type": "magento2-module",
-    "version": "1.0.1",
     "license": "OSL-3.0",
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vladflonta/magento2-webapi-log",
+    "name": "zero1/magento2-webapi-log",
     "description": "Logger for webapi REST requests.",
     "authors":[{
         "name": "Vlad Flonta",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -25,6 +25,11 @@
                     <source_model>VladFlonta\WebApiLog\Model\Config\Source\Services</source_model>
                     <comment>Web API REST services which would not be logged.</comment>
                 </field>
+                <field id="enable_integration_name" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Record Integration Name</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If the request is made via OAuth, record the name of the intregation the request is associated with.</comment>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
When you have multiple integrations it isn't easy to distinguish requests between them.
This adds the integration name to the log file.
![image](https://github.com/vladflonta/magento2-webapi-log/assets/6369163/8811d4d0-3659-4160-921a-071886d4e3a4)

![image](https://github.com/vladflonta/magento2-webapi-log/assets/6369163/748fe8e0-c4ad-4f9c-b550-fa4a23a74ae6)
